### PR TITLE
Making test deleteById able to pass when run by itself

### DIFF
--- a/src/test/java/org/springframework/data/ebean/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/org/springframework/data/ebean/repository/UserRepositoryIntegrationTest.java
@@ -99,6 +99,7 @@ public class UserRepositoryIntegrationTest {
 
   @Test
   public void deleteById() throws Exception {
+    user = new User("Xuegui", "Yuan", "yuanxuegui@163.com");
     userRepository.deleteById(1L);
     assertEquals(false, userRepository.findById(1L).isPresent());
 


### PR DESCRIPTION
Currently, test `UserRepositoryIntegrationTest.deleteById` fails when run by itself. This pull request proposes a fix to make the test pass when run by itself by creating a new `User` instance to be saved.

Please let me know if you want to discuss the changes more.